### PR TITLE
Add peer dependency and fix lint staged pattern

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,11 +1,11 @@
-const lintFile = "eslint --cache --fix --quiet";
-const formatFile = "prettier --ignore-unknown --write";
-const sortPackageJson = "better-sort-package-json";
+const formatFiles = "prettier --ignore-unknown --write";
+const lintFiles = "eslint --cache --fix --quiet";
+const sortPackageJsonFiles = "node bin/cli.js";
 
 const config = {
-  "*,!*.{js,md},!package.json": [formatFile],
-  "*.{js,md}": [lintFile, formatFile],
-  "package.json": [sortPackageJson, formatFile],
+  "!(*.{js,md}|package.json)": [formatFiles],
+  "*.{js,md}": [lintFiles, formatFiles],
+  "package.json": [sortPackageJsonFiles, formatFiles],
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3"
   },
+  "peerDependencies": {
+    "@commitlint/cli": "^19.5.0"
+  },
   "engines": {
     "node": ">=16.9.0"
   },


### PR DESCRIPTION
This PR adds `@commitlint/cli` as a peer dependency as this shareable config file requires it. In addition, a fix to the pattern used in `lint-staged` was added.